### PR TITLE
fix: remove default config values to pass HomeAssistant add-on linting

### DIFF
--- a/mcp-server/config.yaml
+++ b/mcp-server/config.yaml
@@ -12,16 +12,13 @@ arch:
   - i386
 init: false
 startup: services
-boot: auto
 watchdog: "tcp://[HOST]:[PORT:6789]"
 realtime: false
 stdin: false
-auto_uart: false
 homeassistant: 2024.10.0
 hassio_api: true
 homeassistant_api: true
 auth_api: true
-apparmor: true
 ports:
   6789/tcp: null
 ports_description:
@@ -60,15 +57,7 @@ map:
   - media:ro
 panel_icon: mdi:robot
 panel_title: MCP Claude
-ingress: false
-ingress_port: 8099
-ingress_entry: /
-ingress_stream: false
 stage: stable
-advanced: false
-host_network: false
-host_pid: false
-host_ipc: false
 backup_exclude:
   - "*.log"
   - "*.cache"


### PR DESCRIPTION
## Fix Lint Issues

This PR addresses the lint failures in the CI/CD pipeline by removing default configuration values from config.yaml.

### Changes
Removed the following fields that were using default values:
- `boot: auto` (default value)
- `auto_uart: false` (default value)
- `apparmor: true` (default value)
- `ingress` fields (all default/false)
- `advanced: false` (default value)
- `host_network: false` (default value)
- `host_pid: false` (default value)
- `host_ipc: false` (default value)

### Impact
- ✅ Fixes lint job failures in GitHub Actions
- ✅ No functional changes - only removes redundant default values
- ✅ Complies with HomeAssistant add-on best practices

### Testing
- Lint checks should now pass
- Add-on functionality remains unchanged